### PR TITLE
feat: add periodic reporting (weekly, monthly, quarterly, custom)

### DIFF
--- a/app/Console/Commands/GeneratePeriodicReports.php
+++ b/app/Console/Commands/GeneratePeriodicReports.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Http\Controllers\ReportController;
+use Illuminate\Console\Command;
+
+/**
+ * app/Console/Commands/GeneratePeriodicReports.php
+ *
+ * Console command om periodieke rapporten automatisch te genereren.
+ * Kan handmatig via 'php artisan reports:generate' worden aangeroepen
+ * of via een scheduler ingepland.
+ */
+class GeneratePeriodicReports extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'reports:generate {type?}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Genereer periodieke rapporten (weekly, monthly, quarterly) of alles als type niet opgegeven.';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $type = $this->argument('type');
+        $controller = new ReportController(app('App\Services\ReportService'));
+
+        if ($type === 'weekly' || !$type) {
+            $this->info('Genereren wekelijks rapport...');
+            $controller->generateWeekly();
+            $this->line('✓ Wekelijks rapport gegenereerd.');
+        }
+
+        if ($type === 'monthly' || !$type) {
+            $this->info('Genereren maandelijks rapport...');
+            $controller->generateMonthly();
+            $this->line('✓ Maandelijks rapport gegenereerd.');
+        }
+
+        if ($type === 'quarterly' || !$type) {
+            $this->info('Genereren kwartaalrapport...');
+            $controller->generateQuarterly();
+            $this->line('✓ Kwartaalrapport gegenereerd.');
+        }
+
+        $this->info('Alle gespecificeerde rapporten zijn gegenereerd.');
+
+        return Command::SUCCESS;
+    }
+}

--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Report;
+use App\Services\ReportService;
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+
+/**
+ * app/Http/Controllers/ReportController.php
+ *
+ * Controller voor het beheren van periodieke rapportages.
+ * Handelt requests af voor generering, opzoeking en download van rapporten.
+ */
+class ReportController extends Controller
+{
+    protected $reportService;
+
+    public function __construct(ReportService $reportService)
+    {
+        $this->reportService = $reportService;
+    }
+
+    /**
+     * Toon overzicht van alle gegenereerde rapporten (alleen Beheerders).
+     */
+    public function index(Request $request)
+    {
+        $this->authorize('beheerder');
+
+        $reports = Report::orderByDesc('generated_at')
+            ->paginate(15);
+
+        return Inertia::render('Reports/Index', [
+            'reports' => $reports,
+        ]);
+    }
+
+    /**
+     * Toon gedetailleerde rapport pagina.
+     */
+    public function show(Report $report)
+    {
+        $this->authorize('beheerder');
+
+        return Inertia::render('Reports/Show', [
+            'report' => $report,
+        ]);
+    }
+
+    /**
+     * Genereer een nieuw rapport voor gegeven periode.
+     */
+    public function generate(Request $request)
+    {
+        $this->authorize('beheerder');
+
+        $validated = $request->validate([
+            'report_type' => 'required|in:weekly,monthly,quarterly,custom',
+            'period_start' => 'nullable|date',
+            'period_end' => 'nullable|date',
+        ]);
+
+        $reportType = $validated['report_type'];
+        
+        // Bepaal start en eind datum
+        if ($reportType === 'custom') {
+            $startDate = Carbon::parse($validated['period_start'] ?? now());
+            $endDate = Carbon::parse($validated['period_end'] ?? now());
+        } else {
+            $dates = ReportService::getPeriodDates($reportType);
+            $startDate = $dates['start'];
+            $endDate = $dates['end'];
+        }
+
+        // Controleer of rapport al bestaat voor deze periode
+        $existing = Report::where('report_type', $reportType)
+            ->where('period_start', $startDate)
+            ->where('period_end', $endDate)
+            ->first();
+
+        if ($existing) {
+            return redirect()->route('reports.show', $existing->id)
+                ->with('message', 'Rapport voor deze periode bestaat al.');
+        }
+
+        // Genereer nieuwe rapport
+        $report = $this->reportService->generateReport($reportType, $startDate, $endDate);
+
+        return redirect()->route('reports.show', $report->id)
+            ->with('message', 'Rapport succesvol gegenereerd.');
+    }
+
+    /**
+     * Download rapport als JSON.
+     */
+    public function download(Report $report)
+    {
+        $this->authorize('beheerder');
+
+        $filename = "rapport_{$report->report_type}_{$report->period_start->format('Y-m-d')}.json";
+
+        return response()->json($report->data_summary, 200, [
+            'Content-Disposition' => "attachment; filename=$filename",
+        ]);
+    }
+
+    /**
+     * Auto-genereer wekelijks rapport voor vorige week (via scheduled job).
+     */
+    public function generateWeekly()
+    {
+        $lastWeek = now()->subWeek();
+        $dates = ReportService::getPeriodDates('weekly', $lastWeek);
+
+        $existing = Report::where('report_type', 'weekly')
+            ->where('period_start', $dates['start'])
+            ->first();
+
+        if (!$existing) {
+            $this->reportService->generateReport('weekly', $dates['start'], $dates['end']);
+        }
+    }
+
+    /**
+     * Auto-genereer maandelijks rapport voor vorige maand (via scheduled job).
+     */
+    public function generateMonthly()
+    {
+        $lastMonth = now()->subMonth();
+        $dates = ReportService::getPeriodDates('monthly', $lastMonth);
+
+        $existing = Report::where('report_type', 'monthly')
+            ->where('period_start', $dates['start'])
+            ->first();
+
+        if (!$existing) {
+            $this->reportService->generateReport('monthly', $dates['start'], $dates['end']);
+        }
+    }
+
+    /**
+     * Auto-genereer kwartaalrapport voor vorig kwartaal (via scheduled job).
+     */
+    public function generateQuarterly()
+    {
+        $lastQuarter = now()->subQuarters(1);
+        $dates = ReportService::getPeriodDates('quarterly', $lastQuarter);
+
+        $existing = Report::where('report_type', 'quarterly')
+            ->where('period_start', $dates['start'])
+            ->first();
+
+        if (!$existing) {
+            $this->reportService->generateReport('quarterly', $dates['start'], $dates['end']);
+        }
+    }
+}

--- a/app/Models/Report.php
+++ b/app/Models/Report.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+/**
+ * app/Models/Report.php
+ *
+ * Model voor periodieke rapportages (wekelijks, maandelijks, kwartaal, custom).
+ * Slaat gegenereerde rapporten op met samengevatte statistieken en metadata.
+ */
+class Report extends Model
+{
+    protected $fillable = [
+        'report_type',      // 'weekly', 'monthly', 'quarterly', 'custom'
+        'period_start',     // Start datum/tijd van rapportageperiode
+        'period_end',       // Eind datum/tijd van rapportageperiode
+        'data_summary',     // JSON blob met statistieken
+        'generated_at',     // Moment van generering
+    ];
+
+    protected $casts = [
+        'period_start' => 'datetime',
+        'period_end' => 'datetime',
+        'generated_at' => 'datetime',
+        'data_summary' => 'array',
+    ];
+
+    /**
+     * Haal alle overtredingen op die in deze rapportageperiode vallen.
+     */
+    public function overtredingen()
+    {
+        return Overtreding::whereBetween('created_at', [$this->period_start, $this->period_end])->get();
+    }
+
+    /**
+     * Haal alle controlerondes op die in deze periode zijn afgerond.
+     */
+    public function controleRondes()
+    {
+        return ControleRonde::whereBetween('eind_tijd', [$this->period_start, $this->period_end])
+            ->where('status', 'afgerond')
+            ->get();
+    }
+
+    /**
+     * Format rapport als leesbare string voor export/preview.
+     */
+    public function formattedSummary(): string
+    {
+        $data = $this->data_summary ?? [];
+        return json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+    }
+}

--- a/app/Services/ReportService.php
+++ b/app/Services/ReportService.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Report;
+use App\Models\Overtreding;
+use App\Models\ControleRonde;
+use App\Models\OvertredingType;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * app/Services/ReportService.php
+ *
+ * Service voor het genereren van periodieke rapportages.
+ * Aggregeert overtredingen, rondes en statistieken voor gegeven periodes.
+ */
+class ReportService
+{
+    /**
+     * Genereer een rapport voor een gegeven periode en type.
+     */
+    public function generateReport(string $reportType, Carbon $startDate, Carbon $endDate): Report
+    {
+        $dataSummary = $this->aggregateData($startDate, $endDate);
+
+        $report = Report::create([
+            'report_type' => $reportType,
+            'period_start' => $startDate,
+            'period_end' => $endDate,
+            'data_summary' => $dataSummary,
+            'generated_at' => now(),
+        ]);
+
+        return $report;
+    }
+
+    /**
+     * Aggregeer alle relevante statistieken voor een gegeven periode.
+     */
+    private function aggregateData(Carbon $startDate, Carbon $endDate): array
+    {
+        return [
+            'total_overtredingen' => $this->getTotalOvertredingen($startDate, $endDate),
+            'total_rondes' => $this->getTotalRondes($startDate, $endDate),
+            'top_overtredingTypes' => $this->getTopOvertredingTypes($startDate, $endDate),
+            'top_controleurs' => $this->getTopControleurs($startDate, $endDate),
+            'top_wateren' => $this->getTopWateren($startDate, $endDate),
+            'maatregel_breakdown' => $this->getMaatregelBreakdown($startDate, $endDate),
+            'recidive_count' => $this->getRecidiveCount($startDate, $endDate),
+            'vispas_ingenomen_count' => $this->getVispasIngenomenCount($startDate, $endDate),
+        ];
+    }
+
+    /**
+     * Totaal aantal overtredingen in periode.
+     */
+    private function getTotalOvertredingen(Carbon $startDate, Carbon $endDate): int
+    {
+        return Overtreding::whereBetween('created_at', [$startDate, $endDate])->count();
+    }
+
+    /**
+     * Totaal aantal afgeronde controlerondes in periode.
+     */
+    private function getTotalRondes(Carbon $startDate, Carbon $endDate): int
+    {
+        return ControleRonde::whereBetween('eind_tijd', [$startDate, $endDate])
+            ->where('status', 'afgerond')
+            ->count();
+    }
+
+    /**
+     * Top 5 meest voorkomende overtredingstypen.
+     */
+    private function getTopOvertredingTypes(Carbon $startDate, Carbon $endDate): array
+    {
+        return Overtreding::whereBetween('overtredingen.created_at', [$startDate, $endDate])
+            ->join('overtreding_types', 'overtredingen.overtreding_type_id', '=', 'overtreding_types.id')
+            ->select('overtreding_types.code', 'overtreding_types.omschrijving', DB::raw('count(*) as count'))
+            ->groupBy('overtreding_types.id', 'overtreding_types.code', 'overtreding_types.omschrijving')
+            ->orderByDesc('count')
+            ->limit(5)
+            ->get()
+            ->toArray();
+    }
+
+    /**
+     * Top 5 meest actieve controleurs.
+     */
+    private function getTopControleurs(Carbon $startDate, Carbon $endDate): array
+    {
+        return ControleRonde::whereBetween('controle_rondes.eind_tijd', [$startDate, $endDate])
+            ->where('controle_rondes.status', 'afgerond')
+            ->join('users', 'controle_rondes.user_id', '=', 'users.id')
+            ->select('users.id', 'users.name', DB::raw('count(*) as rondes_count'))
+            ->groupBy('users.id', 'users.name')
+            ->orderByDesc('rondes_count')
+            ->limit(5)
+            ->get()
+            ->toArray();
+    }
+
+    /**
+     * Top 5 meest gecontroleerde wateren.
+     */
+    private function getTopWateren(Carbon $startDate, Carbon $endDate): array
+    {
+        return ControleRonde::whereBetween('controle_rondes.eind_tijd', [$startDate, $endDate])
+            ->where('controle_rondes.status', 'afgerond')
+            ->join('waters', 'controle_rondes.water_id', '=', 'waters.id')
+            ->select('waters.id', 'waters.naam', DB::raw('count(*) as control_count'))
+            ->groupBy('waters.id', 'waters.naam')
+            ->orderByDesc('control_count')
+            ->limit(5)
+            ->get()
+            ->toArray();
+    }
+
+    /**
+     * Uitsplitsing van genomen maatregelen.
+     */
+    private function getMaatregelBreakdown(Carbon $startDate, Carbon $endDate): array
+    {
+        return Overtreding::whereBetween('overtredingen.created_at', [$startDate, $endDate])
+            ->select('genomen_maatregel', DB::raw('count(*) as count'))
+            ->groupBy('genomen_maatregel')
+            ->orderByDesc('count')
+            ->get()
+            ->toArray();
+    }
+
+    /**
+     * Aantal recidivegevallen (overtredingen op dezelfde VISpasnummer > 1).
+     */
+    private function getRecidiveCount(Carbon $startDate, Carbon $endDate): int
+    {
+        return Overtreding::whereBetween('overtredingen.created_at', [$startDate, $endDate])
+            ->whereNotNull('vispasnummer')
+            ->select('vispasnummer', DB::raw('count(*) as occ'))
+            ->groupBy('vispasnummer')
+            ->having('occ', '>', 1)
+            ->count();
+    }
+
+    /**
+     * Aantal ingename VISpassen.
+     */
+    private function getVispasIngenomenCount(Carbon $startDate, Carbon $endDate): int
+    {
+        return Overtreding::whereBetween('created_at', [$startDate, $endDate])
+            ->where('vispas_ingenomen', true)
+            ->count();
+    }
+
+    /**
+     * Bepaal start en eind van week/maand/kwartaal op basis van huidige datum.
+     */
+    public static function getPeriodDates(string $reportType, ?Carbon $forDate = null): array
+    {
+        $date = $forDate ?? now();
+
+        return match($reportType) {
+            'weekly' => [
+                'start' => $date->copy()->startOfWeek(),
+                'end' => $date->copy()->endOfWeek(),
+            ],
+            'monthly' => [
+                'start' => $date->copy()->startOfMonth(),
+                'end' => $date->copy()->endOfMonth(),
+            ],
+            'quarterly' => [
+                'start' => $date->copy()->startOfQuarter(),
+                'end' => $date->copy()->endOfQuarter(),
+            ],
+            default => [
+                'start' => $date->copy()->startOfDay(),
+                'end' => $date->copy()->endOfDay(),
+            ],
+        };
+    }
+}

--- a/database/migrations/2025_12_09_000000_create_reports_table.php
+++ b/database/migrations/2025_12_09_000000_create_reports_table.php
@@ -1,0 +1,53 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * database/migrations/*_create_reports_table.php
+ *
+ * Creëert de `reports` tabel voor opslag van gegenereerde periodieke rapporten.
+ * Bevat metadata over de rapportageperiode en een JSON blob met samengevatte statistieken.
+ */
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('reports', function (Blueprint $table) {
+            $table->id();
+
+            // Type rapport: 'weekly', 'monthly', 'quarterly', 'custom'
+            $table->enum('report_type', ['weekly', 'monthly', 'quarterly', 'custom'])
+                ->default('weekly')
+                ->comment('Type van periodieke rapportage');
+
+            // Rapportageperiode: start en eind
+            $table->dateTime('period_start')->comment('Start van rapportageperiode');
+            $table->dateTime('period_end')->comment('Eind van rapportageperiode');
+
+            // JSON blob met samengevatte data (aantal overtredingen, top types, etc.)
+            $table->json('data_summary')->nullable()->comment('Samengevatte statistieken en KPI\'s in JSON formaat');
+
+            // Moment van generering
+            $table->dateTime('generated_at')->nullable()->comment('Moment waarop rapport is gegenereerd');
+
+            // Standaard Laravel timestamps
+            $table->timestamps();
+
+            // Index voor snelle opzoeking op periode en type
+            $table->index(['report_type', 'period_start', 'period_end']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('reports');
+    }
+};

--- a/resources/js/Pages/Reports/Index.vue
+++ b/resources/js/Pages/Reports/Index.vue
@@ -1,0 +1,121 @@
+<script setup>
+// Reports/Index.vue
+// Toont overzicht van alle gegenereerde periodieke rapporten met genereer-formulier.
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
+import { Head, Link, router } from '@inertiajs/vue3';
+import { ref } from 'vue';
+import PrimaryButton from '@/Components/PrimaryButton.vue';
+
+defineProps({
+    reports: Object,
+});
+
+const reportType = ref('weekly');
+const periodStart = ref('');
+const periodEnd = ref('');
+const loading = ref(false);
+
+const generateReport = () => {
+    loading.value = true;
+    router.post(route('reports.generate'), {
+        report_type: reportType.value,
+        period_start: periodStart.value || null,
+        period_end: periodEnd.value || null,
+    }, {
+        onFinish: () => {
+            loading.value = false;
+        },
+    });
+};
+
+const downloadReport = (reportId) => {
+    window.location.href = route('reports.download', reportId);
+};
+</script>
+
+<template>
+    <Head title="Rapporten" />
+
+    <AuthenticatedLayout>
+        <template #header>
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">Periodieke Rapporten</h2>
+        </template>
+
+        <div class="py-12">
+            <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+                <!-- Genereer nieuw rapport formulier -->
+                <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6 mb-6">
+                    <h3 class="text-lg font-semibold text-gray-900 mb-4">Nieuw Rapport Genereren</h3>
+
+                    <div class="space-y-4">
+                        <div>
+                            <label class="block text-sm font-medium text-gray-700 mb-1">Rapporttype</label>
+                            <select v-model="reportType" class="w-full border-gray-300 rounded-md shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                                <option value="weekly">Wekelijks</option>
+                                <option value="monthly">Maandelijks</option>
+                                <option value="quarterly">Kwartaal</option>
+                                <option value="custom">Custom Periode</option>
+                            </select>
+                        </div>
+
+                        <div v-if="reportType === 'custom'" class="grid grid-cols-2 gap-4">
+                            <div>
+                                <label class="block text-sm font-medium text-gray-700 mb-1">Startdatum</label>
+                                <input v-model="periodStart" type="date" class="w-full border-gray-300 rounded-md shadow-sm focus:border-indigo-500 focus:ring-indigo-500" />
+                            </div>
+                            <div>
+                                <label class="block text-sm font-medium text-gray-700 mb-1">Einddatum</label>
+                                <input v-model="periodEnd" type="date" class="w-full border-gray-300 rounded-md shadow-sm focus:border-indigo-500 focus:ring-indigo-500" />
+                            </div>
+                        </div>
+
+                        <div>
+                            <PrimaryButton @click="generateReport" :disabled="loading">
+                                {{ loading ? 'Genereren...' : 'Rapport Genereren' }}
+                            </PrimaryButton>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Overzicht gegenereerde rapporten -->
+                <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                    <div class="p-6">
+                        <h3 class="text-lg font-semibold text-gray-900 mb-4">Gegenereerde Rapporten</h3>
+
+                        <div v-if="reports.data.length === 0" class="text-gray-500 text-center py-6">
+                            Geen rapporten gegenereerd. Genereer er een hierboven.
+                        </div>
+
+                        <table v-else class="min-w-full divide-y divide-gray-200">
+                            <thead class="bg-gray-50">
+                                <tr>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Rapporttype</th>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Periode</th>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Gegenereerd op</th>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Acties</th>
+                                </tr>
+                            </thead>
+                            <tbody class="bg-white divide-y divide-gray-200">
+                                <tr v-for="report in reports.data" :key="report.id">
+                                    <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                                        {{ report.report_type }}
+                                    </td>
+                                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
+                                        {{ new Date(report.period_start).toLocaleDateString() }} - {{ new Date(report.period_end).toLocaleDateString() }}
+                                    </td>
+                                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
+                                        {{ new Date(report.generated_at).toLocaleString() }}
+                                    </td>
+                                    <td class="px-6 py-4 whitespace-nowrap text-sm space-x-2">
+                                        <Link :href="route('reports.show', report.id)" class="text-indigo-600 hover:text-indigo-900">Bekijk</Link>
+                                        <button @click="downloadReport(report.id)" class="text-indigo-600 hover:text-indigo-900">Download</button>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </AuthenticatedLayout>
+</template>

--- a/resources/js/Pages/Reports/Show.vue
+++ b/resources/js/Pages/Reports/Show.vue
@@ -1,0 +1,148 @@
+<script setup>
+// Reports/Show.vue
+// Toont details van een gegenereerd rapport met statistieken en exportmogelijkheden.
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
+import { Head, Link } from '@inertiajs/vue3';
+
+defineProps({
+    report: Object,
+});
+
+const downloadAsJson = () => {
+    const filename = `rapport_${report.report_type}_${new Date(report.period_start).toISOString().split('T')[0]}.json`;
+    const dataStr = JSON.stringify(report.data_summary, null, 2);
+    const dataUri = 'data:application/json;charset=utf-8,' + encodeURIComponent(dataStr);
+
+    const exportFileDefaultName = filename;
+
+    const linkElement = document.createElement('a');
+    linkElement.setAttribute('href', dataUri);
+    linkElement.setAttribute('download', exportFileDefaultName);
+    linkElement.click();
+};
+</script>
+
+<template>
+    <Head title="Rapport Details" />
+
+    <AuthenticatedLayout>
+        <template #header>
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">Rapport: {{ report.report_type }}</h2>
+        </template>
+
+        <div class="py-12">
+            <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+                <!-- Rapport metadata -->
+                <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6 mb-6">
+                    <h3 class="text-lg font-semibold text-gray-900 mb-4">Rapportdetails</h3>
+
+                    <div class="grid grid-cols-2 gap-4 mb-4">
+                        <div>
+                            <p class="text-sm text-gray-600">Rapporttype</p>
+                            <p class="font-semibold">{{ report.report_type }}</p>
+                        </div>
+                        <div>
+                            <p class="text-sm text-gray-600">Periode</p>
+                            <p class="font-semibold">{{ new Date(report.period_start).toLocaleDateString() }} - {{ new Date(report.period_end).toLocaleDateString() }}</p>
+                        </div>
+                        <div>
+                            <p class="text-sm text-gray-600">Gegenereerd op</p>
+                            <p class="font-semibold">{{ new Date(report.generated_at).toLocaleString() }}</p>
+                        </div>
+                    </div>
+
+                    <button @click="downloadAsJson" class="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700">
+                        Download als JSON
+                    </button>
+                </div>
+
+                <!-- Samenvattingsstatistieken -->
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                    <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                        <p class="text-sm text-gray-600">Totaal Overtredingen</p>
+                        <p class="text-3xl font-bold text-red-600">{{ report.data_summary.total_overtredingen }}</p>
+                    </div>
+
+                    <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                        <p class="text-sm text-gray-600">Totaal Controlerondes</p>
+                        <p class="text-3xl font-bold text-blue-600">{{ report.data_summary.total_rondes }}</p>
+                    </div>
+
+                    <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                        <p class="text-sm text-gray-600">Ingename VISpassen</p>
+                        <p class="text-3xl font-bold text-orange-600">{{ report.data_summary.vispas_ingenomen_count }}</p>
+                    </div>
+
+                    <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                        <p class="text-sm text-gray-600">Recidivegevallen</p>
+                        <p class="text-3xl font-bold text-purple-600">{{ report.data_summary.recidive_count }}</p>
+                    </div>
+                </div>
+
+                <!-- Top Overtredingstypes -->
+                <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6 mt-6">
+                    <h3 class="text-lg font-semibold text-gray-900 mb-4">Top Overtredingstypes</h3>
+                    <table class="min-w-full divide-y divide-gray-200">
+                        <thead>
+                            <tr>
+                                <th class="px-4 py-2 text-left text-sm font-medium text-gray-700">Code</th>
+                                <th class="px-4 py-2 text-left text-sm font-medium text-gray-700">Omschrijving</th>
+                                <th class="px-4 py-2 text-left text-sm font-medium text-gray-700">Aantal</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr v-for="type in report.data_summary.top_overtredingTypes" :key="type.code" class="border-b">
+                                <td class="px-4 py-2 text-sm">{{ type.code }}</td>
+                                <td class="px-4 py-2 text-sm">{{ type.omschrijving }}</td>
+                                <td class="px-4 py-2 text-sm font-bold">{{ type.count }}</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+
+                <!-- Top Controleurs -->
+                <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6 mt-6">
+                    <h3 class="text-lg font-semibold text-gray-900 mb-4">Meest Actieve Controleurs</h3>
+                    <table class="min-w-full divide-y divide-gray-200">
+                        <thead>
+                            <tr>
+                                <th class="px-4 py-2 text-left text-sm font-medium text-gray-700">Naam</th>
+                                <th class="px-4 py-2 text-left text-sm font-medium text-gray-700">Rondes</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr v-for="controleur in report.data_summary.top_controleurs" :key="controleur.id" class="border-b">
+                                <td class="px-4 py-2 text-sm">{{ controleur.name }}</td>
+                                <td class="px-4 py-2 text-sm font-bold">{{ controleur.rondes_count }}</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+
+                <!-- Top Wateren -->
+                <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6 mt-6">
+                    <h3 class="text-lg font-semibold text-gray-900 mb-4">Meest Gecontroleerde Wateren</h3>
+                    <table class="min-w-full divide-y divide-gray-200">
+                        <thead>
+                            <tr>
+                                <th class="px-4 py-2 text-left text-sm font-medium text-gray-700">Water</th>
+                                <th class="px-4 py-2 text-left text-sm font-medium text-gray-700">Controles</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr v-for="water in report.data_summary.top_wateren" :key="water.id" class="border-b">
+                                <td class="px-4 py-2 text-sm">{{ water.naam }}</td>
+                                <td class="px-4 py-2 text-sm font-bold">{{ water.control_count }}</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+
+                <!-- Terug link -->
+                <div class="mt-6">
+                    <Link href="/reports" class="text-indigo-600 hover:text-indigo-900">← Terug naar rapporten</Link>
+                </div>
+            </div>
+        </div>
+    </AuthenticatedLayout>
+</template>

--- a/routes/web.php
+++ b/routes/web.php
@@ -68,6 +68,12 @@ Route::middleware('auth')->group(function () {
     // CUSTOM ACTIE: SNEL WATER TOEVOEGEN
     // Route voor een snelle POST-actie om een nieuw water (locatie) toe te voegen vanuit de controle-flow.
     Route::post('/waters/store-quick', [WaterQuickAddController::class, 'store'])->name('waters.store-quick');
+
+    // PERIODIEKE RAPPORTAGES
+    // Routes voor beheerders om wekelijks, maandelijks, kwartaal en custom rapporten in te zien en te downloaden.
+    Route::resource('reports', \App\Http\Controllers\ReportController::class)
+        ->only(['index', 'show', 'download']);
+    Route::post('/reports/generate', [\App\Http\Controllers\ReportController::class, 'generate'])->name('reports.generate');
 });
 
 


### PR DESCRIPTION
Implementeert periodieke rapportages met de volgende functies:\n\n- Report model met migrations voor opslag van gegenereerde rapporten\n- ReportService die statistieken aggregeert (overtredingen, rondes, top typen, controleurs, wateren, maatregel breakdowns, recidives)\n- ReportController met endpoints voor index, show, generate, download\n- Vue pagina's Reports/Index.vue en Reports/Show.vue voor beheerders\n- Console command GeneratePeriodicReports voor handmatige/geplande generering\n- Ondersteuning voor: Wekelijks, Maandelijks, Kwartaal en Custom periodes\n- Alleen beschikbaar voor Beheerders\n\nRapporten kunnen worden gedownload als JSON en bevatten:\n- Totaal overtredingen en rondes\n- Top 5 overtredingstypes, controleurs, wateren\n- Maatregel breakdown\n- Recidive en VISpas inname statistieken