### PR TITLE
refactor: move reports feature to beheer (admin) panel

### DIFF
--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -33,7 +33,7 @@ class ReportController extends Controller
         $reports = Report::orderByDesc('generated_at')
             ->paginate(15);
 
-        return Inertia::render('Reports/Index', [
+        return Inertia::render('Beheer/Reports/Index', [
             'reports' => $reports,
         ]);
     }
@@ -45,7 +45,7 @@ class ReportController extends Controller
     {
         abort_unless(auth()->user()->isBeheerder(), 403);
 
-        return Inertia::render('Reports/Show', [
+        return Inertia::render('Beheer/Reports/Show', [
             'report' => $report,
         ]);
     }

--- a/resources/js/Pages/Beheer/Index.vue
+++ b/resources/js/Pages/Beheer/Index.vue
@@ -58,6 +58,14 @@ import { Head, Link } from '@inertiajs/vue3';
                                 </Link>
                                 <p class="text-sm text-gray-500">Definieer en beheer de types overtredingen die tijdens controles vastgelegd kunnen worden.</p>
                             </div>
+
+                            <!-- 5. Periodieke Rapporten -->
+                            <div class="py-2 px-4 hover:bg-gray-50 transition duration-150 cursor-pointer">
+                                <Link :href="route('beheer.reports.index')" class="text-blue-600 hover:text-blue-800 font-bold text-base block">
+                                    📊 Periodieke Rapporten
+                                </Link>
+                                <p class="text-sm text-gray-500">Genereer en bekijk wekelijks, maandelijks, en kwartaalrapporten met statistieken en analyses.</p>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/resources/js/Pages/Beheer/Reports/Index.vue
+++ b/resources/js/Pages/Beheer/Reports/Index.vue
@@ -1,0 +1,121 @@
+<script setup>
+// Beheer/Reports/Index.vue
+// Toont overzicht van alle gegenereerde periodieke rapporten met genereer-formulier.
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
+import { Head, Link, router } from '@inertiajs/vue3';
+import { ref } from 'vue';
+import PrimaryButton from '@/Components/PrimaryButton.vue';
+
+defineProps({
+    reports: Object,
+});
+
+const reportType = ref('weekly');
+const periodStart = ref('');
+const periodEnd = ref('');
+const loading = ref(false);
+
+const generateReport = () => {
+    loading.value = true;
+    router.post(route('beheer.reports.generate'), {
+        report_type: reportType.value,
+        period_start: periodStart.value || null,
+        period_end: periodEnd.value || null,
+    }, {
+        onFinish: () => {
+            loading.value = false;
+        },
+    });
+};
+
+const downloadReport = (reportId) => {
+    window.location.href = route('beheer.reports.download', reportId);
+};
+</script>
+
+<template>
+    <Head title="Rapporten" />
+
+    <AuthenticatedLayout>
+        <template #header>
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">Periodieke Rapporten</h2>
+        </template>
+
+        <div class="py-12">
+            <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+                <!-- Genereer nieuw rapport formulier -->
+                <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6 mb-6">
+                    <h3 class="text-lg font-semibold text-gray-900 mb-4">Nieuw Rapport Genereren</h3>
+
+                    <div class="space-y-4">
+                        <div>
+                            <label class="block text-sm font-medium text-gray-700 mb-1">Rapporttype</label>
+                            <select v-model="reportType" class="w-full border-gray-300 rounded-md shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                                <option value="weekly">Wekelijks</option>
+                                <option value="monthly">Maandelijks</option>
+                                <option value="quarterly">Kwartaal</option>
+                                <option value="custom">Custom Periode</option>
+                            </select>
+                        </div>
+
+                        <div v-if="reportType === 'custom'" class="grid grid-cols-2 gap-4">
+                            <div>
+                                <label class="block text-sm font-medium text-gray-700 mb-1">Startdatum</label>
+                                <input v-model="periodStart" type="date" class="w-full border-gray-300 rounded-md shadow-sm focus:border-indigo-500 focus:ring-indigo-500" />
+                            </div>
+                            <div>
+                                <label class="block text-sm font-medium text-gray-700 mb-1">Einddatum</label>
+                                <input v-model="periodEnd" type="date" class="w-full border-gray-300 rounded-md shadow-sm focus:border-indigo-500 focus:ring-indigo-500" />
+                            </div>
+                        </div>
+
+                        <div>
+                            <PrimaryButton @click="generateReport" :disabled="loading">
+                                {{ loading ? 'Genereren...' : 'Rapport Genereren' }}
+                            </PrimaryButton>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Overzicht gegenereerde rapporten -->
+                <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                    <div class="p-6">
+                        <h3 class="text-lg font-semibold text-gray-900 mb-4">Gegenereerde Rapporten</h3>
+
+                        <div v-if="reports.data.length === 0" class="text-gray-500 text-center py-6">
+                            Geen rapporten gegenereerd. Genereer er een hierboven.
+                        </div>
+
+                        <table v-else class="min-w-full divide-y divide-gray-200">
+                            <thead class="bg-gray-50">
+                                <tr>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Rapporttype</th>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Periode</th>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Gegenereerd op</th>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Acties</th>
+                                </tr>
+                            </thead>
+                            <tbody class="bg-white divide-y divide-gray-200">
+                                <tr v-for="report in reports.data" :key="report.id">
+                                    <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                                        {{ report.report_type }}
+                                    </td>
+                                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
+                                        {{ new Date(report.period_start).toLocaleDateString() }} - {{ new Date(report.period_end).toLocaleDateString() }}
+                                    </td>
+                                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
+                                        {{ new Date(report.generated_at).toLocaleString() }}
+                                    </td>
+                                    <td class="px-6 py-4 whitespace-nowrap text-sm space-x-2">
+                                        <Link :href="route('beheer.reports.show', report.id)" class="text-indigo-600 hover:text-indigo-900">Bekijk</Link>
+                                        <button @click="downloadReport(report.id)" class="text-indigo-600 hover:text-indigo-900">Download</button>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </AuthenticatedLayout>
+</template>

--- a/resources/js/Pages/Beheer/Reports/Show.vue
+++ b/resources/js/Pages/Beheer/Reports/Show.vue
@@ -1,0 +1,148 @@
+<script setup>
+// Beheer/Reports/Show.vue
+// Toont details van een gegenereerd rapport met statistieken en exportmogelijkheden.
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
+import { Head, Link } from '@inertiajs/vue3';
+
+defineProps({
+    report: Object,
+});
+
+const downloadAsJson = () => {
+    const filename = `rapport_${report.report_type}_${new Date(report.period_start).toISOString().split('T')[0]}.json`;
+    const dataStr = JSON.stringify(report.data_summary, null, 2);
+    const dataUri = 'data:application/json;charset=utf-8,' + encodeURIComponent(dataStr);
+
+    const exportFileDefaultName = filename;
+
+    const linkElement = document.createElement('a');
+    linkElement.setAttribute('href', dataUri);
+    linkElement.setAttribute('download', exportFileDefaultName);
+    linkElement.click();
+};
+</script>
+
+<template>
+    <Head title="Rapport Details" />
+
+    <AuthenticatedLayout>
+        <template #header>
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">Rapport: {{ report.report_type }}</h2>
+        </template>
+
+        <div class="py-12">
+            <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+                <!-- Rapport metadata -->
+                <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6 mb-6">
+                    <h3 class="text-lg font-semibold text-gray-900 mb-4">Rapportdetails</h3>
+
+                    <div class="grid grid-cols-2 gap-4 mb-4">
+                        <div>
+                            <p class="text-sm text-gray-600">Rapporttype</p>
+                            <p class="font-semibold">{{ report.report_type }}</p>
+                        </div>
+                        <div>
+                            <p class="text-sm text-gray-600">Periode</p>
+                            <p class="font-semibold">{{ new Date(report.period_start).toLocaleDateString() }} - {{ new Date(report.period_end).toLocaleDateString() }}</p>
+                        </div>
+                        <div>
+                            <p class="text-sm text-gray-600">Gegenereerd op</p>
+                            <p class="font-semibold">{{ new Date(report.generated_at).toLocaleString() }}</p>
+                        </div>
+                    </div>
+
+                    <button @click="downloadAsJson" class="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700">
+                        Download als JSON
+                    </button>
+                </div>
+
+                <!-- Samenvattingsstatistieken -->
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                    <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                        <p class="text-sm text-gray-600">Totaal Overtredingen</p>
+                        <p class="text-3xl font-bold text-red-600">{{ report.data_summary.total_overtredingen }}</p>
+                    </div>
+
+                    <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                        <p class="text-sm text-gray-600">Totaal Controlerondes</p>
+                        <p class="text-3xl font-bold text-blue-600">{{ report.data_summary.total_rondes }}</p>
+                    </div>
+
+                    <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                        <p class="text-sm text-gray-600">Ingename VISpassen</p>
+                        <p class="text-3xl font-bold text-orange-600">{{ report.data_summary.vispas_ingenomen_count }}</p>
+                    </div>
+
+                    <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                        <p class="text-sm text-gray-600">Recidivegevallen</p>
+                        <p class="text-3xl font-bold text-purple-600">{{ report.data_summary.recidive_count }}</p>
+                    </div>
+                </div>
+
+                <!-- Top Overtredingstypes -->
+                <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6 mt-6">
+                    <h3 class="text-lg font-semibold text-gray-900 mb-4">Top Overtredingstypes</h3>
+                    <table class="min-w-full divide-y divide-gray-200">
+                        <thead>
+                            <tr>
+                                <th class="px-4 py-2 text-left text-sm font-medium text-gray-700">Code</th>
+                                <th class="px-4 py-2 text-left text-sm font-medium text-gray-700">Omschrijving</th>
+                                <th class="px-4 py-2 text-left text-sm font-medium text-gray-700">Aantal</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr v-for="type in report.data_summary.top_overtredingTypes" :key="type.code" class="border-b">
+                                <td class="px-4 py-2 text-sm">{{ type.code }}</td>
+                                <td class="px-4 py-2 text-sm">{{ type.omschrijving }}</td>
+                                <td class="px-4 py-2 text-sm font-bold">{{ type.count }}</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+
+                <!-- Top Controleurs -->
+                <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6 mt-6">
+                    <h3 class="text-lg font-semibold text-gray-900 mb-4">Meest Actieve Controleurs</h3>
+                    <table class="min-w-full divide-y divide-gray-200">
+                        <thead>
+                            <tr>
+                                <th class="px-4 py-2 text-left text-sm font-medium text-gray-700">Naam</th>
+                                <th class="px-4 py-2 text-left text-sm font-medium text-gray-700">Rondes</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr v-for="controleur in report.data_summary.top_controleurs" :key="controleur.id" class="border-b">
+                                <td class="px-4 py-2 text-sm">{{ controleur.name }}</td>
+                                <td class="px-4 py-2 text-sm font-bold">{{ controleur.rondes_count }}</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+
+                <!-- Top Wateren -->
+                <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6 mt-6">
+                    <h3 class="text-lg font-semibold text-gray-900 mb-4">Meest Gecontroleerde Wateren</h3>
+                    <table class="min-w-full divide-y divide-gray-200">
+                        <thead>
+                            <tr>
+                                <th class="px-4 py-2 text-left text-sm font-medium text-gray-700">Water</th>
+                                <th class="px-4 py-2 text-left text-sm font-medium text-gray-700">Controles</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr v-for="water in report.data_summary.top_wateren" :key="water.id" class="border-b">
+                                <td class="px-4 py-2 text-sm">{{ water.naam }}</td>
+                                <td class="px-4 py-2 text-sm font-bold">{{ water.control_count }}</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+
+                <!-- Terug link -->
+                <div class="mt-6">
+                    <Link :href="route('beheer.reports.index')" class="text-indigo-600 hover:text-indigo-900">← Terug naar rapporten</Link>
+                </div>
+            </div>
+        </div>
+    </AuthenticatedLayout>
+</template>

--- a/routes/web.php
+++ b/routes/web.php
@@ -68,12 +68,6 @@ Route::middleware('auth')->group(function () {
     // CUSTOM ACTIE: SNEL WATER TOEVOEGEN
     // Route voor een snelle POST-actie om een nieuw water (locatie) toe te voegen vanuit de controle-flow.
     Route::post('/waters/store-quick', [WaterQuickAddController::class, 'store'])->name('waters.store-quick');
-
-    // PERIODIEKE RAPPORTAGES
-    // Routes voor beheerders om wekelijks, maandelijks, kwartaal en custom rapporten in te zien en te downloaden.
-    Route::resource('reports', \App\Http\Controllers\ReportController::class)
-        ->only(['index', 'show', 'download']);
-    Route::post('/reports/generate', [\App\Http\Controllers\ReportController::class, 'generate'])->name('reports.generate');
 });
 
 
@@ -83,6 +77,15 @@ Route::middleware('auth')->group(function () {
 Route::middleware(['auth', 'beheerder'])->group(function () {
     // Basis Beheer Dashboard: Hoofdpagina voor beheerders met managementoverzichten.
     Route::get('/beheer', [App\Http\Controllers\BeheerController::class, 'index'])->name('beheer.index');
+
+    // PERIODIEKE RAPPORTAGES
+    // Routes voor beheerders om wekelijks, maandelijks, kwartaal en custom rapporten in te zien en te downloaden.
+    Route::resource('beheer/reports', \App\Http\Controllers\ReportController::class)
+        ->only(['index', 'show'])
+        ->names('beheer.reports');
+    Route::post('/beheer/reports/generate', [\App\Http\Controllers\ReportController::class, 'generate'])->name('beheer.reports.generate');
+    Route::get('/beheer/reports/{report}/download', [\App\Http\Controllers\ReportController::class, 'download'])->name('beheer.reports.download');
+
 
     // GEBRUIKERS BEHEER (CRUD)
     // Resource routes voor het beheren van gebruikers (overzicht, aanmaken, bewerken, verwijderen).


### PR DESCRIPTION
## Changes

- Moved Reports Vue components from `resources/js/Pages/Reports/` to `resources/js/Pages/Beheer/Reports/`
- Updated ReportController to render Beheer/Reports views instead of Reports views
- Reorganized routes: reports now under `/beheer/reports` with `beheer.reports.*` route names
- Added Rapportages link to Beheer Index dashboard with emoji (📊)
- Routes now properly scoped to beheer middleware group (admin-only access)

## Routes Changed

- Old: `GET /reports` → New: `GET /beheer/reports`
- Old: `GET /reports/{id}` → New: `GET /beheer/reports/{id}`
- Old: `POST /reports/generate` → New: `POST /beheer/reports/generate`
- Old: `GET /reports/{id}/download` → New: `GET /beheer/reports/{id}/download`

## Benefits

- Reports feature is now logically grouped with other admin functions
- Cleaner navigation structure
- Consistent with existing beheer pattern (Users, Waters, Strafmaten, OvertredingTypes)